### PR TITLE
Added support for path-like objects in Python 3.6

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,409 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality. This option is deprecated
+# and it will be removed in Pylint 2.0.
+optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=dict-iter-method,buffer-builtin,cmp-method,apply-builtin,standarderror-builtin,backtick,long-builtin,unicode-builtin,import-star-module-level,parameter-unpacking,raising-string,raw_input-builtin,execfile-builtin,xrange-builtin,getslice-method,hex-method,old-octal-literal,coerce-builtin,indexing-exception,no-absolute-import,using-cmp-argument,old-ne-operator,map-builtin-not-iterating,long-suffix,dict-view-method,nonzero-method,delslice-method,old-division,coerce-method,oct-method,next-method-called,useless-suppression,suppressed-message,reduce-builtin,unichr-builtin,intern-builtin,zip-builtin-not-iterating,setslice-method,print-statement,input-builtin,filter-builtin-not-iterating,range-builtin-not-iterating,metaclass-assignment,round-builtin,old-raise-syntax,reload-builtin,basestring-builtin,file-builtin,cmp-builtin,unpacking-in-except
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]". This option is deprecated
+# and it will be removed in Pylint 2.0.
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=yes
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Regular expression matching correct method names
+# added camel case starting with capital letter
+method-rgx=[a-z_][a-z0-9_]{2,30}|_{0,2}[A-Z][A-Za-z0-9]+$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct function names
+# added camel case starting with capital letter
+function-rgx=[a-z_][a-z0-9_]{2,30}|_{0,2}[A-Z][A-Za-z0-9]+$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,30}|(__.*__))$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[ELIF]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line as per Google coding style.
+max-line-length=80
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=(_+[a-zA-Z0-9]*?$)|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,future.builtins
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=optparse
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/.pylintrc
+++ b/.pylintrc
@@ -194,8 +194,9 @@ max-nested-blocks=5
 
 [FORMAT]
 
-# Maximum number of characters on a single line as per Google coding style.
-max-line-length=80
+# Maximum number of characters on a single line
+# increased from 80 to 100
+max-line-length=100
 
 # Regexp for a line that is allowed to be longer than the limit.
 ignore-long-lines=^\s*(# )?<?https?://\S+>?$

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6-dev"
 
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install importlib unittest2; fi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ The release versions are PyPi releases.
 
 #### New Features
  * `io.open`, `os.open`: support for `encoding` argument
- * `os.makedirs`: support for `exist_ok` argument
+ * `os.makedirs`: support for `exist_ok` argument (Python >= 3.2)
  * support for fake `io.open()`
  * support for mount points
  * support for hard links
@@ -25,7 +25,7 @@ The release versions are PyPi releases.
  * Windows support:
      * support for alternative path separator (Windows)
      * support for case-insensitive filesystems
-     * supprt for drive letters and UNC paths
+     * support for drive letters and UNC paths
  * support for filesystem size
  * `shutil.rmtree`: support for `ignore_errors` and `onerror` arguments
  * support for `os.fsync()` and `os.fdatasync()`
@@ -40,7 +40,7 @@ The release versions are PyPi releases.
 
 ## Version 2.7
 
-### Infrastructure
+#### Infrastructure
  * moved repository from GoogleCode to GitHub, merging 3 projects
  * added continous integration testing with Travis CI
  * added usage documentation in project wiki

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
-# Release Notes
+# Release Notes 
+The release versions are PyPi releases.
 
 ## Unreleased
 
@@ -32,3 +33,34 @@
  * `shutil.copy` error with bytes contents (#105)
  * mtime and ctime not updated on content changes
  * Reading from fake block devices doesn't work (#24)
+
+## Version 2.7
+
+### Infrastructure
+ * moved repository from GoogleCode to GitHub, merging 3 projects
+ * added continous integration testing with Travis CI
+ * added usage documentation in project wiki
+ * better support for pypi releases
+ 
+#### New Features
+ * added direct unit test support in `fake_filesystem_unittest` 
+   (transparently patches all calls to faked implementations)
+ * added support for doctests
+ * added support for cygwin
+ * better support for Python 3
+
+#### Fixes
+ * `chown` incorrectly accepts non-integer uid/gid arguments
+ * incorrect behavior of `relpath`, `abspath` and `normpath` on Windows.
+ * Python 3 `open` in binary mode not working (#32)
+ * `mkstemp` returns no valid file descriptor (#19)
+ * `open` methods lack `IOError` for prohibited operations (#18)
+ * incorrectly resolved relative path (#3)
+ * `FakeFileOpen` keyword args do not match the `__builtin__` equivalents (#5)
+ * relative paths not supported (#16, #17)
+
+## Older Versions
+As there have been three different projects that have been merged together 
+for release 2.7, no older release notes are given.
+The following versions are still avaliable in PyPi:
+ * 1.1, 1.2, 2.0, 2.1, 2.2, 2.3 and 2.4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,34 @@
+# Release Notes
+
+## Unreleased
+
+#### New Features
+ * support for `os.scandir` (Python >= 3.5)
+ * option to not fake modules named `path`
+ * `glob.glob`, `glob.iglob`: support for `recursive` argument
+ * support for `glob.iglob`
+
+## Version 2.9
+
+#### New Features
+ * `io.open`, `os.open`: support for `encoding` argument
+ * `os.makedirs`: support for `exist_ok` argument
+ * support for fake `io.open()`
+ * support for mount points
+ * support for hard links
+ * support for float times (mtime, ctime)
+ * Windows support:
+     * support for alternative path separator (Windows)
+     * support for case-insensitive filesystems
+     * supprt for drive letters and UNC paths
+ * support for filesystem size
+ * `shutil.rmtree`: support for `ignore_errors` and `onerror` arguments
+ * support for `os.fsync()` and `os.fdatasync()`
+ * `os.walk`: Support for `followlinks` argument
+ 
+#### Fixes
+ * `shutil` functions like `make_archive` do not work with pyfakefs (#104)
+ * file permissions on deletion not correctly handled (#27)
+ * `shutil.copy` error with bytes contents (#105)
+ * mtime and ctime not updated on content changes
+ * Reading from fake block devices doesn't work (#24)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,9 +4,13 @@ The release versions are PyPi releases.
 ## Unreleased
 
 #### New Features
+ * support for `pathlib` (Python >= 3.4)
+ * support for `os.replace` (Python >= 3.3)
+ * `os.access`, `os.chmod`, `os.chown`, `os.stat`, `os.utime`:
+   support for `follow_symlinks` argument (Python >= 3.3)
  * support for `os.scandir` (Python >= 3.5)
  * option to not fake modules named `path`
- * `glob.glob`, `glob.iglob`: support for `recursive` argument
+ * `glob.glob`, `glob.iglob`: support for `recursive` argument (Python >= 3.5)
  * support for `glob.iglob`
 
 ## Version 2.9

--- a/all_tests.py
+++ b/all_tests.py
@@ -17,6 +17,7 @@
 """A test suite that runs all tests for pyfakefs at once."""
 
 import unittest
+import sys
 
 import fake_filesystem_glob_test
 import fake_filesystem_shutil_test
@@ -25,6 +26,9 @@ import fake_filesystem_vs_real_test
 import fake_tempfile_test
 import fake_filesystem_unittest_test
 import example_test
+
+if sys.version_info >= (3, 4):
+    import fake_pathlib_test
 
 
 class AllTests(unittest.TestSuite):
@@ -41,11 +45,13 @@ class AllTests(unittest.TestSuite):
             loader.loadTestsFromModule(fake_filesystem_unittest_test),
             loader.loadTestsFromModule(example_test),
         ])
+        if sys.version_info >= (3, 4):
+            self.addTests([
+                loader.loadTestsFromModule(fake_pathlib_test)
+            ])
         return self
 
 
 if __name__ == '__main__':
-    import sys
-
     result = unittest.TextTestRunner(verbosity=2).run(AllTests().suite())
     sys.exit(int(not result.wasSuccessful()))

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -2460,7 +2460,10 @@ class FakePathModuleTest(TestCase):
         path_foo = '/path/to/foo'
         path_bar = '/path/to/bar'
         path_other = '/some/where/else'
-        self.assertRaises(ValueError, self.path.relpath, None)
+        if sys.version_info >= (3, 6):
+            self.assertRaises(TypeError, self.path.relpath, None)
+        else:
+            self.assertRaises(ValueError, self.path.relpath, None)
         self.assertRaises(ValueError, self.path.relpath, '')
         if sys.version_info < (2, 7):
             # The real Python 2.6 os.path.relpath('/path/to/foo') actually does

--- a/fake_filesystem_test.py
+++ b/fake_filesystem_test.py
@@ -2460,10 +2460,7 @@ class FakePathModuleTest(TestCase):
         path_foo = '/path/to/foo'
         path_bar = '/path/to/bar'
         path_other = '/some/where/else'
-        if sys.version_info >= (3, 6):
-            self.assertRaises(TypeError, self.path.relpath, None)
-        else:
-            self.assertRaises(ValueError, self.path.relpath, None)
+        self.assertRaises(ValueError, self.path.relpath, None)
         self.assertRaises(ValueError, self.path.relpath, '')
         if sys.version_info < (2, 7):
             # The real Python 2.6 os.path.relpath('/path/to/foo') actually does

--- a/fake_filesystem_unittest_test.py
+++ b/fake_filesystem_unittest_test.py
@@ -25,6 +25,9 @@ import shutil
 import tempfile
 import sys
 
+if sys.version_info >= (3, 4):
+    import pathlib
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -127,6 +130,16 @@ class TestPyfakefsUnittest(TestPyfakefsUnittestBase):  # pylint: disable=R0904
             with open('%s/fake_file.txt' % td, 'w') as f:
                 self.assertTrue(self.fs.Exists(td))
 
+    @unittest.skipIf(sys.version_info < (3, 4), "pathlib new in Python 3.4")
+    def test_fakepathlib(self):
+        with pathlib.Path('/fake_file.txt') as p:
+            with p.open('w') as f:
+                f.write('text')
+        is_windows = sys.platform.startswith('win')
+        if is_windows:
+            self.assertTrue(self.fs.Exists(r'\fake_file.txt'))
+        else:
+            self.assertTrue(self.fs.Exists('/fake_file.txt'))
 
 import math as path
 

--- a/fake_pathlib_test.py
+++ b/fake_pathlib_test.py
@@ -1,0 +1,457 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unittests for fake_pathlib.
+As most of fake_pathlib is a wrapper around fake_filesystem methods, the tests
+are there mostly to ensure basic functionality.
+Note that many of the tests are directly taken from examples in the python docs.
+"""
+
+import os
+import stat
+import unittest
+
+import sys
+
+from pyfakefs import fake_filesystem
+from pyfakefs import fake_pathlib
+
+is_windows = sys.platform == 'win32'
+
+
+class FakePathlibInitializationTest(unittest.TestCase):
+    def setUp(self):
+        filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+        filesystem.supports_drive_letter = False
+        self.pathlib = fake_pathlib.FakePathlibModule(filesystem)
+        self.path = self.pathlib.Path
+
+    def test_initialization_type(self):
+        """Make sure tests for class type will work"""
+        path = self.path('/test')
+        if is_windows:
+            self.assertTrue(isinstance(path, self.pathlib.WindowsPath))
+            self.assertTrue(isinstance(path, self.pathlib.PureWindowsPath))
+            self.assertTrue(self.pathlib.PurePosixPath())
+            self.assertRaises(NotImplementedError, self.pathlib.PosixPath)
+        else:
+            self.assertTrue(isinstance(path, self.pathlib.PosixPath))
+            self.assertTrue(isinstance(path, self.pathlib.PurePosixPath))
+            self.assertTrue(self.pathlib.PureWindowsPath())
+            self.assertRaises(NotImplementedError, self.pathlib.WindowsPath)
+
+    def test_init_with_segments(self):
+        """Basic initialization tests - taken from pathlib.Path documentation"""
+        self.assertEqual(self.path('/', 'foo', 'bar', 'baz'),
+                         self.path('/foo/bar/baz'))
+        self.assertEqual(self.path(), self.path('.'))
+        self.assertEqual(self.path(self.path('foo'), self.path('bar')),
+                         self.path('foo/bar'))
+        self.assertEqual(self.path('/etc') / 'init.d' / 'reboot',
+                         self.path('/etc/init.d/reboot'))
+
+    def test_init_collapse(self):
+        """Tests for collapsing path during initialization - taken from pathlib.PurePath documentation"""
+        self.assertEqual(self.path('foo//bar'), self.path('foo/bar'))
+        self.assertEqual(self.path('foo/./bar'), self.path('foo/bar'))
+        self.assertNotEqual(self.path('foo/../bar'), self.path('foo/bar'))
+        self.assertEqual(self.path('/etc', '/usr', 'lib64'), self.path('/usr/lib64'))
+
+    def test_path_parts(self):
+        path = self.path('/foo/bar/setup.py')
+        self.assertEqual(path.parts, ('/', 'foo', 'bar', 'setup.py'))
+        self.assertEqual(path.drive, '')
+        self.assertEqual(path.root, '/')
+        self.assertEqual(path.anchor, '/')
+        self.assertEqual(path.name, 'setup.py')
+        self.assertEqual(path.stem, 'setup')
+        self.assertEqual(path.suffix, '.py')
+        self.assertEqual(path.parent, self.path('/foo/bar'))
+        self.assertEqual(path.parents[0], self.path('/foo/bar'))
+        self.assertEqual(path.parents[1], self.path('/foo'))
+        self.assertEqual(path.parents[2], self.path('/'))
+
+    def test_is_absolute(self):
+        self.assertTrue(self.path('/a/b').is_absolute())
+        self.assertFalse(self.path('a/b').is_absolute())
+
+
+class FakePathlibInitializationWithDriveTest(unittest.TestCase):
+    def setUp(self):
+        filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+        filesystem.supports_drive_letter = True
+        pathlib = fake_pathlib.FakePathlibModule(filesystem)
+        self.path = pathlib.Path
+
+    def test_init_with_segments(self):
+        """Basic initialization tests - taken from pathlib.Path documentation"""
+        self.assertEqual(self.path('c:/', 'foo', 'bar', 'baz'), self.path('c:/foo/bar/baz'))
+        self.assertEqual(self.path(), self.path('.'))
+        self.assertEqual(self.path(self.path('foo'), self.path('bar')), self.path('foo/bar'))
+        self.assertEqual(self.path('c:/Users') / 'john' / 'data', self.path('c:/Users/john/data'))
+
+    def test_init_collapse(self):
+        """Tests for collapsing path during initialization - taken from pathlib.PurePath documentation"""
+        self.assertEqual(self.path('c:/Windows', 'd:bar'), self.path('d:bar'))
+        self.assertEqual(self.path('c:/Windows', '/Program Files'), self.path('c:/Program Files'))
+
+    def test_path_parts(self):
+        path = self.path('d:/python scripts/setup.py')
+        self.assertEqual(path.parts, ('d:/', 'python scripts', 'setup.py'))
+        self.assertEqual(path.drive, 'd:')
+        self.assertEqual(path.root, '/')
+        self.assertEqual(path.anchor, 'd:/')
+        self.assertEqual(path.name, 'setup.py')
+        self.assertEqual(path.stem, 'setup')
+        self.assertEqual(path.suffix, '.py')
+        self.assertEqual(path.parent, self.path('d:/python scripts'))
+        self.assertEqual(path.parents[0], self.path('d:/python scripts'))
+        self.assertEqual(path.parents[1], self.path('d:/'))
+
+    def test_is_absolute(self):
+        self.assertTrue(self.path('c:/a/b').is_absolute())
+        self.assertFalse(self.path('/a/b').is_absolute())
+        self.assertFalse(self.path('c:').is_absolute())
+        self.assertTrue(self.path('//some/share').is_absolute())
+
+
+class FakePathlibPurePathTest(unittest.TestCase):
+    """Tests functionality present in PurePath class."""
+
+    def setUp(self):
+        filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+        filesystem.supports_drive_letter = True
+        pathlib = fake_pathlib.FakePathlibModule(filesystem)
+        self.path = pathlib.Path
+
+    def test_is_reserved(self):
+        self.assertFalse(self.path('/dev').is_reserved())
+        self.assertFalse(self.path('/').is_reserved())
+        if is_windows:
+            self.assertTrue(self.path('COM1').is_reserved())
+            self.assertTrue(self.path('nul.txt').is_reserved())
+        else:
+            self.assertFalse(self.path('COM1').is_reserved())
+            self.assertFalse(self.path('nul.txt').is_reserved())
+
+    def test_joinpath(self):
+        self.assertEqual(self.path('/etc').joinpath('passwd'),
+                         self.path('/etc/passwd'))
+        self.assertEqual(self.path('/etc').joinpath(self.path('passwd')),
+                         self.path('/etc/passwd'))
+        self.assertEqual(self.path('/foo').joinpath('bar', 'baz'),
+                         self.path('/foo/bar/baz'))
+        self.assertEqual(self.path('c:').joinpath('/Program Files'),
+                         self.path('c:/Program Files'))
+
+    def test_match(self):
+        self.assertTrue(self.path('a/b.py').match('*.py'))
+        self.assertTrue(self.path('/a/b/c.py').match('b/*.py'))
+        self.assertFalse(self.path('/a/b/c.py').match('a/*.py'))
+        self.assertTrue(self.path('/a.py').match('/*.py'))
+        self.assertFalse(self.path('a/b.py').match('/*.py'))
+
+    def test_relative_to(self):
+        self.assertEqual(self.path('/etc/passwd').relative_to('/'), self.path('etc/passwd'))
+        self.assertEqual(self.path('/etc/passwd').relative_to('/'), self.path('etc/passwd'))
+        self.assertRaises(ValueError, self.path('passwd').relative_to, '/usr')
+
+    def test_with_name(self):
+        self.assertEqual(self.path('c:/Downloads/pathlib.tar.gz').with_name('setup.py'),
+                         self.path('c:/Downloads/setup.py'))
+        self.assertRaises(ValueError, self.path('c:/').with_name, 'setup.py')
+
+    def test_with_suffix(self):
+        self.assertEqual(self.path('c:/Downloads/pathlib.tar.gz').with_suffix('.bz2'),
+                         self.path('c:/Downloads/pathlib.tar.bz2'))
+        self.assertEqual(self.path('README').with_suffix('.txt'),
+                         self.path('README.txt'))
+
+
+class FakePathlibFileObjectPropertyTest(unittest.TestCase):
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+        self.filesystem.supports_drive_letter = False
+        pathlib = fake_pathlib.FakePathlibModule(self.filesystem)
+        self.path = pathlib.Path
+        self.filesystem.CreateFile('/home/jane/test.py', st_size=100, st_mode=stat.S_IFREG | 0o666)
+        self.filesystem.CreateDirectory('/home/john')
+        self.filesystem.CreateLink('/john', '/home/john')
+        self.filesystem.CreateLink('/test.py', '/home/jane/test.py')
+        self.filesystem.CreateLink('/broken_dir_link', '/home/none')
+        self.filesystem.CreateLink('/broken_file_link', '/home/none/test.py')
+
+    def test_exists(self):
+        self.assertTrue(self.path('/home/jane/test.py').exists())
+        self.assertTrue(self.path('/home/jane').exists())
+        self.assertFalse(self.path('/home/jane/test').exists())
+        self.assertTrue(self.path('/john').exists())
+        self.assertTrue(self.path('/test.py').exists())
+        self.assertFalse(self.path('/broken_dir_link').exists())
+        self.assertFalse(self.path('/broken_file_link').exists())
+
+    def test_is_dir(self):
+        self.assertFalse(self.path('/home/jane/test.py').is_dir())
+        self.assertTrue(self.path('/home/jane').is_dir())
+        self.assertTrue(self.path('/john').is_dir())
+        self.assertFalse(self.path('/test.py').is_dir())
+        self.assertFalse(self.path('/broken_dir_link').is_dir())
+        self.assertFalse(self.path('/broken_file_link').is_dir())
+
+    def test_is_file(self):
+        self.assertTrue(self.path('/home/jane/test.py').is_file())
+        self.assertFalse(self.path('/home/jane').is_file())
+        self.assertFalse(self.path('/john').is_file())
+        self.assertTrue(self.path('/test.py').is_file())
+        self.assertFalse(self.path('/broken_dir_link').is_file())
+        self.assertFalse(self.path('/broken_file_link').is_file())
+
+    def test_is_symlink(self):
+        self.assertFalse(self.path('/home/jane/test.py').is_symlink())
+        self.assertFalse(self.path('/home/jane').is_symlink())
+        self.assertTrue(self.path('/john').is_symlink())
+        self.assertTrue(self.path('/test.py').is_symlink())
+        self.assertTrue(self.path('/broken_dir_link').is_symlink())
+        self.assertTrue(self.path('/broken_file_link').is_symlink())
+
+    def test_stat(self):
+        file_object = self.filesystem.ResolveObject('/home/jane/test.py')
+
+        stat_result = self.path('/test.py').stat()
+        self.assertFalse(stat_result[stat.ST_MODE] & stat.S_IFDIR)
+        self.assertTrue(stat_result[stat.ST_MODE] & stat.S_IFREG)
+        self.assertEqual(stat_result[stat.ST_INO], file_object.st_ino)
+        self.assertEqual(stat_result[stat.ST_SIZE], 100)
+        self.assertEqual(stat_result[stat.ST_MTIME], file_object.st_mtime)
+
+    def test_lstat(self):
+        link_object = self.filesystem.LResolveObject('/test.py')
+
+        stat_result = self.path('/test.py').lstat()
+        self.assertTrue(stat_result[stat.ST_MODE] & stat.S_IFREG)
+        self.assertTrue(stat_result[stat.ST_MODE] & stat.S_IFLNK)
+        self.assertEqual(stat_result[stat.ST_INO], link_object.st_ino)
+        self.assertEqual(stat_result[stat.ST_SIZE], len('/home/jane/test.py'))
+        self.assertEqual(stat_result[stat.ST_MTIME], link_object.st_mtime)
+
+    def test_chmod(self):
+        file_object = self.filesystem.ResolveObject('/home/jane/test.py')
+        link_object = self.filesystem.LResolveObject('/test.py')
+        self.path('/test.py').chmod(0o444)
+        self.assertEqual(file_object.st_mode, stat.S_IFREG | 0o444)
+        self.assertEqual(link_object.st_mode, stat.S_IFLNK | 0o777)
+
+    def test_lchmod(self):
+        file_object = self.filesystem.ResolveObject('/home/jane/test.py')
+        link_object = self.filesystem.LResolveObject('/test.py')
+        if not hasattr(os, "lchmod"):
+            self.assertRaises(NotImplementedError, self.path('/test.py').lchmod, 0o444)
+        else:
+            self.path('/test.py').lchmod(0o444)
+            self.assertEqual(file_object.st_mode, stat.S_IFREG | 0o666)
+            self.assertEqual(link_object.st_mode, stat.S_IFLNK | 0o444)
+
+    def test_resolve(self):
+        self.filesystem.cwd = '/home/antoine'
+        self.filesystem.CreateDirectory('/home/antoine/docs')
+        self.filesystem.CreateFile('/home/antoine/setup.py')
+        self.assertEqual(self.path().resolve(),
+                         self.path('/home/antoine'))
+        self.assertEqual(self.path('docs/../setup.py').resolve(),
+                         self.path('/home/antoine/setup.py'))
+
+    def test_cwd(self):
+        self.filesystem.cwd = '/home/jane'
+        self.assertEqual(self.path.cwd(), self.path('/home/jane'))
+
+    def test_expanduser(self):
+        if is_windows:
+            self.assertEqual(self.path('~').expanduser(),
+                             self.path(os.environ['USERPROFILE'].replace('\\', '/')))
+        else:
+            self.assertEqual(self.path('~').expanduser(),
+                             self.path(os.environ['HOME']))
+
+    def test_home(self):
+        if is_windows:
+            self.assertEqual(self.path.home(),
+                             self.path(os.environ['USERPROFILE'].replace('\\', '/')))
+        else:
+            self.assertEqual(self.path.home(),
+                             self.path(os.environ['HOME']))
+
+
+class FakePathlibPathFileOperationTest(unittest.TestCase):
+    """Tests methods related to file and directory handling."""
+
+    def setUp(self):
+        self.filesystem = fake_filesystem.FakeFilesystem(path_separator='/')
+        self.filesystem.supports_drive_letter = False
+        self.filesystem.is_case_sensitive = True
+        pathlib = fake_pathlib.FakePathlibModule(self.filesystem)
+        self.path = pathlib.Path
+
+    def test_exists(self):
+        self.filesystem.CreateFile('/home/jane/test.py')
+        self.filesystem.CreateDirectory('/home/john')
+        self.filesystem.CreateLink('/john', '/home/john')
+        self.filesystem.CreateLink('/none', '/home/none')
+
+        self.assertTrue(self.path('/home/jane/test.py').exists())
+        self.assertTrue(self.path('/home/jane').exists())
+        self.assertTrue(self.path('/john').exists())
+        self.assertFalse(self.path('/none').exists())
+        self.assertFalse(self.path('/home/jane/test').exists())
+
+    def test_open(self):
+        self.filesystem.CreateDirectory('/foo')
+        self.assertRaises(OSError, self.path('/foo/bar.txt').open)
+        self.path('/foo/bar.txt').open('w')
+        self.assertTrue(self.filesystem.Exists('/foo/bar.txt'))
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'New in version 3.5')
+    def test_read_text(self):
+        self.filesystem.CreateFile('text_file', contents='ерунда', encoding='cyrillic')
+        file_path = self.path('text_file')
+        self.assertEqual(file_path.read_text(encoding='cyrillic'), 'ерунда')
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'New in version 3.5')
+    def test_write_text(self):
+        file_path = self.path('text_file')
+        file_path.write_text('ανοησίες', encoding='greek')
+        self.assertTrue(self.filesystem.Exists('text_file'))
+        file_object = self.filesystem.ResolveObject('text_file')
+        self.assertEqual(file_object.byte_contents.decode('greek'), 'ανοησίες')
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'New in version 3.5')
+    def test_read_bytes(self):
+        self.filesystem.CreateFile('binary_file', contents=b'Binary file contents')
+        file_path = self.path('binary_file')
+        self.assertEqual(file_path.read_bytes(), b'Binary file contents')
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'New in version 3.5')
+    def test_write_bytes(self):
+        file_path = self.path('binary_file')
+        file_path.write_bytes(b'Binary file contents')
+        self.assertTrue(self.filesystem.Exists('binary_file'))
+        file_object = self.filesystem.ResolveObject('binary_file')
+        self.assertEqual(file_object.byte_contents, b'Binary file contents')
+
+    def test_rename(self):
+        self.filesystem.CreateFile('/foo/bar.txt', contents='test')
+        self.path('/foo/bar.txt').rename('foo/baz.txt')
+        self.assertFalse(self.filesystem.Exists('/foo/bar.txt'))
+        file_obj = self.filesystem.ResolveObject('foo/baz.txt')
+        self.assertTrue(file_obj)
+        self.assertEqual(file_obj.contents, 'test')
+
+    def test_replace(self):
+        self.filesystem.CreateFile('/foo/bar.txt', contents='test')
+        self.filesystem.CreateFile('/bar/old.txt', contents='replaced')
+        self.path('/bar/old.txt').replace('foo/bar.txt')
+        self.assertFalse(self.filesystem.Exists('/bar/old.txt'))
+        file_obj = self.filesystem.ResolveObject('foo/bar.txt')
+        self.assertTrue(file_obj)
+        self.assertEqual(file_obj.contents, 'replaced')
+
+    def test_unlink(self):
+        self.filesystem.CreateFile('/foo/bar.txt', contents='test')
+        self.assertTrue(self.filesystem.Exists('/foo/bar.txt'))
+        self.path('/foo/bar.txt').unlink()
+        self.assertFalse(self.filesystem.Exists('/foo/bar.txt'))
+
+    def test_touch_non_existing(self):
+        self.filesystem.CreateDirectory('/foo')
+        self.path('/foo/bar.txt').touch(mode=0o444)
+        file_obj = self.filesystem.ResolveObject('/foo/bar.txt')
+        self.assertTrue(file_obj)
+        self.assertEqual(file_obj.contents, '')
+        self.assertTrue(file_obj.st_mode, stat.S_IFREG | 0o444)
+
+    def test_touch_existing(self):
+        self.filesystem.CreateFile('/foo/bar.txt', contents='test')
+        file_path = self.path('/foo/bar.txt')
+        self.assertRaises(FileExistsError, file_path.touch, exist_ok=False)
+        file_path.touch()
+        file_obj = self.filesystem.ResolveObject('/foo/bar.txt')
+        self.assertTrue(file_obj)
+        self.assertEqual(file_obj.contents, 'test')
+
+    def test_samefile(self):
+        self.filesystem.CreateFile('/foo/bar.txt')
+        self.filesystem.CreateFile('/foo/baz.txt')
+        self.assertRaises(OSError, self.path('/foo/other').samefile, '/foo/other.txt')
+        path = self.path('/foo/bar.txt')
+        self.assertRaises(OSError, path.samefile, '/foo/other.txt')
+        self.assertRaises(OSError, path.samefile, self.path('/foo/other.txt'))
+        self.assertFalse(path.samefile('/foo/baz.txt'))
+        self.assertFalse(path.samefile(self.path('/foo/baz.txt')))
+        self.assertTrue(path.samefile('/foo/../foo/bar.txt'))
+        self.assertTrue(path.samefile(self.path('/foo/../foo/bar.txt')))
+
+    def test_symlink_to(self):
+        self.filesystem.CreateFile('/foo/bar.txt')
+        path = self.path('/link_to_bar')
+        path.symlink_to('/foo/bar.txt')
+        self.assertTrue(self.filesystem.Exists('/link_to_bar'))
+        file_obj = self.filesystem.ResolveObject('/foo/bar.txt')
+        linked_file_obj = self.filesystem.ResolveObject('/link_to_bar')
+        self.assertEqual(file_obj, linked_file_obj)
+        link__obj = self.filesystem.LResolveObject('/link_to_bar')
+        self.assertTrue(path.is_symlink())
+
+    def test_mkdir(self):
+        self.assertRaises(FileNotFoundError, self.path('/foo/bar').mkdir)
+        self.path('/foo/bar').mkdir(parents=True)
+        self.assertTrue(self.filesystem.Exists('/foo/bar'))
+        self.assertRaises(FileExistsError, self.path('/foo/bar').mkdir)
+
+    @unittest.skipIf(sys.version_info < (3, 5), 'exist_ok argument new in Python 3.5')
+    def test_mkdir_exist_ok(self):
+        self.filesystem.CreateDirectory('/foo/bar')
+        self.path('foo/bar').mkdir(exist_ok=True)
+        self.filesystem.CreateFile('/foo/bar/baz')
+        self.assertRaises(FileExistsError, self.path('/foo/bar/baz').mkdir, exist_ok=True)
+
+    def test_rmdir(self):
+        self.filesystem.CreateDirectory('/foo/bar')
+        self.path('/foo/bar').rmdir()
+        self.assertFalse(self.filesystem.Exists('/foo/bar'))
+        self.assertTrue(self.filesystem.Exists('/foo'))
+        self.filesystem.CreateFile('/foo/baz')
+        self.assertRaises(OSError, self.path('/foo').rmdir)
+        self.assertTrue(self.filesystem.Exists('/foo'))
+
+    def test_iterdir(self):
+        self.filesystem.CreateFile('/foo/bar/file1')
+        self.filesystem.CreateFile('/foo/bar/file2')
+        self.filesystem.CreateFile('/foo/bar/file3')
+        path = self.path('/foo/bar')
+        contents = [entry for entry in path.iterdir()]
+        self.assertEqual(3, len(contents))
+        self.assertIn(self.path('/foo/bar/file2'), contents)
+
+    def test_glob(self):
+        self.filesystem.CreateFile('/foo/setup.py')
+        self.filesystem.CreateFile('/foo/all_tests.py')
+        self.filesystem.CreateFile('/foo/README.md')
+        self.filesystem.CreateFile('/foo/setup.pyc')
+        path = self.path('/foo')
+        self.assertEqual(sorted(path.glob('*.py')),
+                         [self.path('/foo/all_tests.py'), self.path('/foo/setup.py')])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fake_tempfile_test.py
+++ b/fake_tempfile_test.py
@@ -103,7 +103,7 @@ class FakeTempfileModuleTest(unittest.TestCase):
 
     def testTempFilenameDir(self):
         """test tempfile._TempFilename(dir=)."""
-        filename = self.tempfile._TempFilename(dir='/dir')
+        filename = self.tempfile._TempFilename(directory='/dir')
         self.assertTrue(filename.startswith('/dir/tmp'))
         self.assertLess(len('/dir/tmpX'), len(filename))
 

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -822,6 +822,8 @@ class FakeFilesystem(object):
         Returns:
           (str) A copy of path with empty components and dot components removed.
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         path = self.NormalizePathSeparator(path)
         drive, path = self.SplitDrive(path)
         is_absolute_path = path.startswith(self.path_separator)
@@ -910,6 +912,8 @@ class FakeFilesystem(object):
           (str) A duple (pathname, basename) for which pathname does not
               end with a slash, and basename does not contain a slash.
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         drive, path = self.SplitDrive(path)
         path = self.NormalizePathSeparator(path)
         path_components = path.split(self.path_separator)
@@ -934,6 +938,8 @@ class FakeFilesystem(object):
         original path.
         Taken from Windows specific implementation in Python 3.5 and slightly adapted.
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if self.supports_drive_letter:
             if len(path) >= 2:
                 path = self.NormalizePathSeparator(path)
@@ -2019,6 +2025,8 @@ class FakePathModule(object):
         """Return True if path is an absolute pathname."""
         if self.filesystem.supports_drive_letter:
             path = self.splitdrive(path)[1]
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if _IS_WINDOWS:
             return len(path) > 0 and path[0] in (self.sep, self.altsep)
         else:
@@ -2065,6 +2073,8 @@ class FakePathModule(object):
             else:
                 return self.os.getcwd()
 
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if not self.isabs(path):
             path = self.join(getcwd(), path)
         elif (self.filesystem.supports_drive_letter and

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -2108,6 +2108,10 @@ class FakePathModule(object):
 
         def relpath(self, path, start=None):
             """ntpath.relpath() needs the cwd passed in the start argument."""
+            if not path:
+                raise ValueError("no path specified")
+            if sys.version_info >= (3, 6):
+                path = os.fspath(path)
             if start is None:
                 start = self.filesystem.cwd
             path = self._os_path.relpath(path, start)

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -1012,7 +1012,8 @@ class FakeFilesystem(object):
           (str) The paths joined by the path separator, starting with the last
               absolute path in paths.
         """
-        paths = [os.fspath(path) for path in paths]
+        if sys.version_info >= (3, 6):
+            paths = [os.fspath(path) for path in paths]
         if len(paths) == 1:
             return paths[0]
         if self.supports_drive_letter:

--- a/pyfakefs/fake_filesystem.py
+++ b/pyfakefs/fake_filesystem.py
@@ -370,7 +370,7 @@ class FakeFile(object):
         """Set the self.st_atime attribute.
 
         Args:
-          st_atime: The desired atime.
+          st_atime: The desired access time.
         """
         self.st_atime = st_atime
 
@@ -378,9 +378,17 @@ class FakeFile(object):
         """Set the self.st_mtime attribute.
 
         Args:
-          st_mtime: The desired mtime.
+          st_mtime: The desired modification time.
         """
         self.st_mtime = st_mtime
+
+    def SetCTime(self, st_ctime):
+        """Set the self.st_ctime attribute.
+
+        Args:
+          st_ctime: The desired creation time.
+        """
+        self.st_ctime = st_ctime
 
     def __str__(self):
         return '%s(%o)' % (self.name, self.st_mode)
@@ -798,6 +806,8 @@ class FakeFilesystem(object):
         Returns:
           The normalized path that will be used internally.
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if self.alternative_path_separator is None or not path:
             return path
         return path.replace(self.alternative_path_separator, self.path_separator)
@@ -822,8 +832,6 @@ class FakeFilesystem(object):
         Returns:
           (str) A copy of path with empty components and dot components removed.
         """
-        if sys.version_info >= (3, 6):
-            path = os.fspath(path)
         path = self.NormalizePathSeparator(path)
         drive, path = self.SplitDrive(path)
         is_absolute_path = path.startswith(self.path_separator)
@@ -912,8 +920,6 @@ class FakeFilesystem(object):
           (str) A duple (pathname, basename) for which pathname does not
               end with a slash, and basename does not contain a slash.
         """
-        if sys.version_info >= (3, 6):
-            path = os.fspath(path)
         drive, path = self.SplitDrive(path)
         path = self.NormalizePathSeparator(path)
         path_components = path.split(self.path_separator)
@@ -1006,6 +1012,7 @@ class FakeFilesystem(object):
           (str) The paths joined by the path separator, starting with the last
               absolute path in paths.
         """
+        paths = [os.fspath(path) for path in paths]
         if len(paths) == 1:
             return paths[0]
         if self.supports_drive_letter:
@@ -1102,6 +1109,8 @@ class FakeFilesystem(object):
         Raises:
           TypeError: if file_path is None
         """
+        if sys.version_info >= (3, 6):
+            file_path = os.fspath(file_path)
         if file_path is None:
             raise TypeError
         if not file_path:
@@ -1204,6 +1213,8 @@ class FakeFilesystem(object):
             # Don't call self.NormalizePath(), as we don't want to prepend self.cwd.
             return self.CollapsePath(link_path)
 
+        if sys.version_info >= (3, 6):
+            file_path = os.fspath(file_path)
         if file_path is None:
             # file.open(None) raises TypeError, so mimic that.
             raise TypeError('Expected file system path string, received None')
@@ -1267,6 +1278,8 @@ class FakeFilesystem(object):
         Raises:
           IOError: if the object is not found
         """
+        if sys.version_info >= (3, 6):
+            file_path = os.fspath(file_path)
         if file_path == self.root.name:
             return self.root
         path_components = self.GetPathComponents(file_path)
@@ -1296,6 +1309,8 @@ class FakeFilesystem(object):
         Raises:
           IOError: if the object is not found
         """
+        if sys.version_info >= (3, 6):
+            file_path = os.fspath(file_path)
         file_path = self.NormalizePath(self.NormalizeCase(file_path))
         return self.GetObjectFromNormalizedPath(file_path)
 
@@ -1313,6 +1328,8 @@ class FakeFilesystem(object):
           IOError: if the object is not found
         """
         if follow_symlinks:
+            if sys.version_info >= (3, 6):
+                file_path = os.fspath(file_path)
             return self.GetObjectFromNormalizedPath(self.ResolvePath(file_path))
         return self.LResolveObject(file_path)
 
@@ -1331,6 +1348,8 @@ class FakeFilesystem(object):
         Raises:
           IOError: if the object is not found
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if path == self.root.name:
             # The root directory will never be a link
             return self.root
@@ -1569,6 +1588,8 @@ class FakeFilesystem(object):
         if not _IS_LINK_SUPPORTED:
             raise OSError("Symbolic links are not supported on Windows before Python 3.2")
         resolved_file_path = self.ResolvePath(file_path)
+        if sys.version_info >= (3, 6):
+            link_target = os.fspath(link_target)
         return self.CreateFile(resolved_file_path, st_mode=stat.S_IFLNK | PERM_DEF,
                                contents=link_target)
 
@@ -1629,6 +1650,8 @@ class FakeFilesystem(object):
           OSError: if the directory name is invalid or parent directory is read only
           or as per FakeFilesystem.AddObject.
         """
+        if sys.version_info >= (3, 6):
+            dir_name = os.fspath(dir_name)
         if self._EndsWithPathSeparator(dir_name):
             dir_name = dir_name[:-1]
 
@@ -1702,6 +1725,8 @@ class FakeFilesystem(object):
         Raises:
           TypeError: if path is None
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if path is None:
             raise TypeError
         try:
@@ -1732,6 +1757,8 @@ class FakeFilesystem(object):
         Raises:
           TypeError: if path is None
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if path is None:
             raise TypeError
         try:
@@ -2056,12 +2083,28 @@ class FakePathModule(object):
         return self.filesystem.IsLink(path)
 
     def getmtime(self, path):
-        """Returns the mtime of the file."""
+        """Returns the modification time of the file."""
         try:
             file_obj = self.filesystem.GetObject(path)
         except IOError as exc:
             raise OSError(errno.ENOENT, str(exc))
         return file_obj.st_mtime
+
+    def getatime(self, path):
+        """Returns the access time of the file."""
+        try:
+            file_obj = self.filesystem.GetObject(path)
+        except IOError as exc:
+            raise OSError(errno.ENOENT, str(exc))
+        return file_obj.st_atime
+
+    def getctime(self, path):
+        """Returns the creation time of the file."""
+        try:
+            file_obj = self.filesystem.GetObject(path)
+        except IOError as exc:
+            raise OSError(errno.ENOENT, str(exc))
+        return file_obj.st_ctime
 
     def abspath(self, path):
         """Return the absolute version of a path."""
@@ -2135,6 +2178,8 @@ class FakePathModule(object):
           True if path is a mount point added to the fake file system.
           Under Windows also returns True for drive and UNC roots (independent of their existence).
         """
+        if sys.version_info >= (3, 6):
+            path = os.fspath(path)
         if not path:
             return False
         normed_path = self.filesystem.NormalizePath(path)

--- a/pyfakefs/fake_filesystem_glob.py
+++ b/pyfakefs/fake_filesystem_glob.py
@@ -127,7 +127,7 @@ class FakeGlobModule(object):
                 yield self._path_module.join(dirname, name)
 
     # These 2 helper functions non-recursively glob inside a literal directory.
-    # They return a list of basenames. `_glob1` accepts a pattern while `_glob0`
+    # They return a list of basenames. `glob1` accepts a pattern while `glob0`
     # takes a literal basename (so it only has to check for its existence).
     def glob1(self, dirname, pattern):
         if not dirname:

--- a/pyfakefs/fake_filesystem_glob.py
+++ b/pyfakefs/fake_filesystem_glob.py
@@ -17,8 +17,8 @@
 Includes:
   FakeGlob: Uses a FakeFilesystem to provide a fake replacement for the
     glob module.
-Note: Code is taken form Python 3.5 and slightly adapted to work with older versions
-      and use the fake os and os.path modules
+Note: Code is taken form Python 3.5 and slightly adapted to work with older
+    versions and use the fake os and os.path modules
 
 Usage:
 >>> from pyfakefs import fake_filesystem
@@ -68,10 +68,11 @@ class FakeGlobModule(object):
         Returns:
             List of strings matching the glob pattern.
         """
-        return list(self.iglob(pathname, recursive=_recursive_from_arg(recursive)))
+        return list(
+            self.iglob(pathname, recursive=_recursive_from_arg(recursive)))
 
     def iglob(self, pathname, recursive=None):
-        """Return an iterator which yields the paths matching a pathname pattern.
+        """Return an iterator yielding the paths matching a pathname pattern.
 
         The pattern may contain shell-style wildcards a la fnmatch.
 
@@ -81,11 +82,11 @@ class FakeGlobModule(object):
             zero or more directories and subdirectories. (>= Python 3.5 only)
         """
         recursive = _recursive_from_arg(recursive)
-        it = self._iglob(pathname, recursive)
+        itr = self._iglob(pathname, recursive)
         if recursive and _isrecursive(pathname):
-            s = next(it)  # skip empty string
-            assert not s
-        return it
+            string = next(itr)  # skip empty string
+            assert not string
+        return itr
 
     def _iglob(self, pathname, recursive):
         dirname, basename = self._path_module.split(pathname)
@@ -106,8 +107,9 @@ class FakeGlobModule(object):
                 for name in self.glob1(dirname, basename):
                     yield name
             return
-        # `self._path_module.split()` returns the argument itself as a dirname if it is a
-        # drive or UNC path.  Prevent an infinite recursion if a drive or UNC path
+        # `self._path_module.split()` returns the argument itself as a dirname
+        # if it is a drive or UNC path.
+        # Prevent an infinite recursion if a drive or UNC path
         # contains magic characters (i.e. r'\\?\C:').
         if dirname != pathname and self.has_magic(dirname):
             dirs = self._iglob(dirname, recursive)
@@ -125,15 +127,17 @@ class FakeGlobModule(object):
                 yield self._path_module.join(dirname, name)
 
     # These 2 helper functions non-recursively glob inside a literal directory.
-    # They return a list of basenames. `glob1` accepts a pattern while `glob0`
+    # They return a list of basenames. `_glob1` accepts a pattern while `_glob0`
     # takes a literal basename (so it only has to check for its existence).
     def glob1(self, dirname, pattern):
         if not dirname:
+            # pylint: disable=undefined-variable
             if sys.version_info >= (3,) and isinstance(pattern, bytes):
                 dirname = bytes(self._os_module.curdir, 'ASCII')
             elif sys.version_info < (3,) and isinstance(pattern, unicode):
-                dirname = unicode(self._os_module.curdir,
-                                  sys.getfilesystemencoding() or sys.getdefaultencoding())
+                dirname = unicode(
+                    self._os_module.curdir,
+                    sys.getfilesystemencoding() or sys.getdefaultencoding())
             else:
                 dirname = self._os_module.curdir
 
@@ -147,17 +151,19 @@ class FakeGlobModule(object):
 
     def glob0(self, dirname, basename):
         if not basename:
-            # `self._path_module.split()` returns an empty basename for paths ending with a
-            # directory separator.  'q*x/' should match only directories.
+            # `self._path_module.split()` returns an empty basename
+            # for paths ending with a directory separator.
+            # 'q*x/' should match only directories.
             if self._path_module.isdir(dirname):
                 return [basename]
         else:
-            if self._path_module.lexists(self._path_module.join(dirname, basename)):
+            if self._path_module.lexists(
+                    self._path_module.join(dirname, basename)):
                 return [basename]
         return []
 
-    # This helper function recursively yields relative pathnames inside a literal
-    # directory.
+    # This helper function recursively yields relative pathnames
+    # inside a literal directory.
     def glob2(self, dirname, pattern):
         assert _isrecursive(pattern)
         yield pattern[:0]
@@ -167,11 +173,13 @@ class FakeGlobModule(object):
     # Recursively yields relative pathnames inside a literal directory.
     def _rlistdir(self, dirname):
         if not dirname:
+            # pylint: disable=undefined-variable
             if sys.version_info >= (3,) and isinstance(dirname, bytes):
                 dirname = bytes(self._os_module.curdir, 'ASCII')
             elif sys.version_info < (3,) and isinstance(dirname, unicode):
-                dirname = unicode(self._os_module.curdir,
-                                  sys.getfilesystemencoding() or sys.getdefaultencoding())
+                dirname = unicode(
+                    self._os_module.curdir,
+                    sys.getfilesystemencoding() or sys.getdefaultencoding())
             else:
                 dirname = self._os_module.curdir
 
@@ -179,21 +187,22 @@ class FakeGlobModule(object):
             names = self._os_module.listdir(dirname)
         except self._os_module.error:
             return
-        for x in names:
-            if not _ishidden(x):
-                yield x
-                path = self._path_module.join(dirname, x) if dirname else x
-                for y in self._rlistdir(path):
-                    yield self._path_module.join(x, y)
+        for name in names:
+            if not _ishidden(name):
+                yield name
+                path = self._path_module.join(dirname,
+                                              name) if dirname else name
+                for dir_name in self._rlistdir(path):
+                    yield self._path_module.join(name, dir_name)
 
     magic_check = re.compile('([*?[])')
     magic_check_bytes = re.compile(b'([*?[])')
 
-    def has_magic(self, s):
-        if isinstance(s, bytes):
-            match = self.magic_check_bytes.search(s)
+    def has_magic(self, string):
+        if isinstance(string, bytes):
+            match = self.magic_check_bytes.search(string)
         else:
-            match = self.magic_check.search(s)
+            match = self.magic_check.search(string)
         return match is not None
 
     def escape(self, pathname):
@@ -234,7 +243,7 @@ def _recursive_from_arg(recursive):
 
 
 def _RunDoctest():
-    # pylint: disable-msg=C6111,C6204,W0406
+    # pylint: disable=import-self
     import doctest
     from pyfakefs import fake_filesystem_glob
     return doctest.testmod(fake_filesystem_glob)

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -80,6 +80,9 @@ class _FakeAccessor(pathlib._Accessor):  # pylint: disable=protected-access
 
     chmod = _wrap_strfunc(FakeFilesystem.ChangeMode)
 
+    if sys.version_info >= (3, 6):
+        scandir = _wrap_strfunc(FakeFilesystem.ScanDir)
+
     if hasattr(os, "lchmod"):
         lchmod = _wrap_strfunc(lambda fs, path, mode: FakeFilesystem.ChangeMode(
             fs, path, mode, follow_symlinks=False))

--- a/pyfakefs/fake_pathlib.py
+++ b/pyfakefs/fake_pathlib.py
@@ -1,0 +1,548 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A fake implementation for pathlib working with FakeFilesystem.
+Usage:
+* With fake_filesystem_unittest:
+  If using fake_filesystem_unittest.TestCase, pathlib gets replaced
+  by fake_pathlib together with other file system related modules.
+
+* Stand-alone with FakeFilesystem:
+  `filesystem = fake_filesystem.FakeFilesystem()`
+  `fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)`
+  `path = fake_pathlib_module.Path('/foo/bar')`
+
+Note: as the implementation is based on FakeFilesystem, all faked classes
+(including PurePosixPath, PosixPath, PureWindowsPath and WindowsPath)
+get the properties of the underlying fake filesystem.
+"""
+
+import os
+import pathlib
+from urllib.parse import quote_from_bytes as urlquote_from_bytes
+
+import sys
+
+import functools
+
+from pyfakefs.fake_filesystem import FakeFileOpen, FakeFilesystem
+
+
+def init_module(filesystem):
+    """Initializes the fake module with the fake file system."""
+    # pylint: disable=protected-access
+    FakePath.filesystem = filesystem
+    FakePathlibModule.PureWindowsPath._flavour = _FakeWindowsFlavour(filesystem)
+    FakePathlibModule.PurePosixPath._flavour = _FakePosixFlavour(filesystem)
+
+
+def _wrap_strfunc(strfunc):
+    @functools.wraps(strfunc)
+    def _wrapped(pathobj, *args):
+        return strfunc(pathobj.filesystem, str(pathobj), *args)
+
+    return staticmethod(_wrapped)
+
+
+def _wrap_binary_strfunc(strfunc):
+    @functools.wraps(strfunc)
+    def _wrapped(pathobj1, pathobj2, *args):
+        return strfunc(pathobj1.filesystem, str(pathobj1), str(pathobj2), *args)
+
+    return staticmethod(_wrapped)
+
+
+def _wrap_binary_strfunc_reverse(strfunc):
+    @functools.wraps(strfunc)
+    def _wrapped(pathobj1, pathobj2, *args):
+        return strfunc(pathobj2.filesystem, str(pathobj2), str(pathobj1), *args)
+
+    return staticmethod(_wrapped)
+
+
+class _FakeAccessor(pathlib._Accessor):  # pylint: disable=protected-access
+    """Accessor which forwards some of the functions to FakeFilesystem methods."""
+
+    stat = _wrap_strfunc(FakeFilesystem.GetStat)
+
+    lstat = _wrap_strfunc(lambda fs, path: FakeFilesystem.GetStat(fs, path, follow_symlinks=False))
+
+    listdir = _wrap_strfunc(FakeFilesystem.ListDir)
+
+    chmod = _wrap_strfunc(FakeFilesystem.ChangeMode)
+
+    if hasattr(os, "lchmod"):
+        lchmod = _wrap_strfunc(lambda fs, path, mode: FakeFilesystem.ChangeMode(
+            fs, path, mode, follow_symlinks=False))
+    else:
+        def lchmod(self, pathobj, mode):
+            """Raises not implemented for Windows systems."""
+            raise NotImplementedError("lchmod() not available on this system")
+
+    mkdir = _wrap_strfunc(FakeFilesystem.MakeDirectory)
+
+    unlink = _wrap_strfunc(FakeFilesystem.RemoveFile)
+
+    rmdir = _wrap_strfunc(FakeFilesystem.RemoveDirectory)
+
+    rename = _wrap_binary_strfunc(FakeFilesystem.RenameObject)
+
+    replace = _wrap_binary_strfunc(lambda fs, old_path, new_path:
+                                   FakeFilesystem.RenameObject(
+                                       fs, old_path, new_path, force_replace=True))
+
+    symlink = _wrap_binary_strfunc_reverse(FakeFilesystem.CreateLink)
+
+    utime = _wrap_strfunc(FakeFilesystem.UpdateTime)
+
+
+_fake_accessor = _FakeAccessor()
+
+
+class _FakeFlavour(pathlib._Flavour):
+    """Fake Flavour implementation used by PurePath and _Flavour"""
+
+    filesystem = None
+    sep = '/'
+    altsep = None
+    has_drv = False
+
+    ext_namespace_prefix = '\\\\?\\'
+
+    drive_letters = (
+        set(chr(x) for x in range(ord('a'), ord('z') + 1)) |
+        set(chr(x) for x in range(ord('A'), ord('Z') + 1))
+    )
+
+    def __init__(self, filesystem):
+        self.filesystem = filesystem
+        self.sep = filesystem.path_separator
+        self.altsep = filesystem.alternative_path_separator
+        self.has_drv = filesystem.supports_drive_letter
+        super(_FakeFlavour, self).__init__()
+
+    @staticmethod
+    def _split_extended_path(path, ext_prefix=ext_namespace_prefix):
+        prefix = ''
+        if path.startswith(ext_prefix):
+            prefix = path[:4]
+            path = path[4:]
+            if path.startswith('UNC\\'):
+                prefix += path[:3]
+                path = '\\' + path[3:]
+        return prefix, path
+
+    def _splitroot_with_drive(self, path, sep):
+        first = path[0:1]
+        second = path[1:2]
+        if second == sep and first == sep:
+            # XXX extended paths should also disable the collapsing of "."
+            # components (according to MSDN docs).
+            prefix, path = self._split_extended_path(path)
+            first = path[0:1]
+            second = path[1:2]
+        else:
+            prefix = ''
+        third = path[2:3]
+        if second == sep and first == sep and third != sep:
+            # is a UNC path:
+            # vvvvvvvvvvvvvvvvvvvvv root
+            # \\machine\mountpoint\directory\etc\...
+            #            directory ^^^^^^^^^^^^^^
+            index = path.find(sep, 2)
+            if index != -1:
+                index2 = path.find(sep, index + 1)
+                # a UNC path can't have two slashes in a row
+                # (after the initial two)
+                if index2 != index + 1:
+                    if index2 == -1:
+                        index2 = len(path)
+                    if prefix:
+                        return prefix + path[1:index2], sep, path[index2 + 1:]
+                    else:
+                        return path[:index2], sep, path[index2 + 1:]
+        drv = root = ''
+        if second == ':' and first in self.drive_letters:
+            drv = path[:2]
+            path = path[2:]
+            first = third
+        if first == sep:
+            root = first
+            path = path.lstrip(sep)
+        return prefix + drv, root, path
+
+    @staticmethod
+    def _splitroot_posix(path, sep):
+        if path and path[0] == sep:
+            stripped_part = path.lstrip(sep)
+            if len(path) - len(stripped_part) == 2:
+                return '', sep * 2, stripped_part
+            else:
+                return '', sep, stripped_part
+        else:
+            return '', '', path
+
+    def splitroot(self, path, sep=None):
+        """Split path into drive, root and rest."""
+        if sep is None:
+            sep = self.filesystem.path_separator
+        if self.filesystem.supports_drive_letter:
+            return self._splitroot_with_drive(path, sep)
+        return self._splitroot_posix(path, sep)
+
+    def casefold(self, s):
+        """Return the lower-case version of s for a case-insensitive filesystem."""
+        if self.filesystem.is_case_sensitive:
+            return s
+        return s.lower()
+
+    def casefold_parts(self, parts):
+        """Return the lower-case version of parts for a case-insensitive filesystem."""
+        if self.filesystem.is_case_sensitive:
+            return parts
+        return [p.lower() for p in parts]
+
+    def resolve(self, path):
+        """Make the path absolute, resolving any symlinks."""
+        return self.filesystem.ResolvePath(str(path))
+
+    def gethomedir(self, username):
+        """Return the home directory of the current user."""
+        if not username:
+            try:
+                return os.environ['HOME']
+            except KeyError:
+                import pwd
+                return pwd.getpwuid(os.getuid()).pw_dir
+        else:
+            import pwd
+            try:
+                return pwd.getpwnam(username).pw_dir
+            except KeyError:
+                raise RuntimeError("Can't determine home directory "
+                                   "for %r" % username)
+
+
+class _FakeWindowsFlavour(_FakeFlavour):
+    """Flavour used by PureWindowsPath with some Windows specific implementations
+    independent of FakeFilesystem properties.
+    """
+    reserved_names = (
+        {'CON', 'PRN', 'AUX', 'NUL'} |
+        {'COM%d' % i for i in range(1, 10)} |
+        {'LPT%d' % i for i in range(1, 10)}
+    )
+
+    def is_reserved(self, parts):
+        """Return True if the path is considered reserved under Windows."""
+
+        # NOTE: the rules for reserved names seem somewhat complicated
+        # (e.g. r"..\NUL" is reserved but not r"foo\NUL").
+        # We err on the side of caution and return True for paths which are
+        # not considered reserved by Windows.
+        if not parts:
+            return False
+        if self.filesystem.supports_drive_letter and parts[0].startswith('\\\\'):
+            # UNC paths are never reserved
+            return False
+        return parts[-1].partition('.')[0].upper() in self.reserved_names
+
+    def make_uri(self, path):
+        """Return a file URI for the given path"""
+
+        # Under Windows, file URIs use the UTF-8 encoding.
+        # original version, not faked
+        # todo: make this part dependent on drive support, add encoding as property
+        drive = path.drive
+        if len(drive) == 2 and drive[1] == ':':
+            # It's a path on a local drive => 'file:///c:/a/b'
+            rest = path.as_posix()[2:].lstrip('/')
+            return 'file:///%s/%s' % (
+                drive, urlquote_from_bytes(rest.encode('utf-8')))
+        else:
+            # It's a path on a network drive => 'file://host/share/a/b'
+            return 'file:' + urlquote_from_bytes(path.as_posix().encode('utf-8'))
+
+    def gethomedir(self, username):
+        """Return the home directory of the current user."""
+
+        # original version, not faked
+        if 'HOME' in os.environ:
+            userhome = os.environ['HOME']
+        elif 'USERPROFILE' in os.environ:
+            userhome = os.environ['USERPROFILE']
+        elif 'HOMEPATH' in os.environ:
+            try:
+                drv = os.environ['HOMEDRIVE']
+            except KeyError:
+                drv = ''
+            userhome = drv + os.environ['HOMEPATH']
+        else:
+            raise RuntimeError("Can't determine home directory")
+
+        if username:
+            # Try to guess user home directory.  By default all users
+            # directories are located in the same place and are named by
+            # corresponding usernames.  If current user home directory points
+            # to nonstandard place, this guess is likely wrong.
+            if os.environ['USERNAME'] != username:
+                drv, root, parts = self.parse_parts((userhome,))
+                if parts[-1] != os.environ['USERNAME']:
+                    raise RuntimeError("Can't determine home directory "
+                                       "for %r" % username)
+                parts[-1] = username
+                if drv or root:
+                    userhome = drv + root + self.join(parts[1:])
+                else:
+                    userhome = self.join(parts)
+        return userhome
+
+
+class _FakePosixFlavour(_FakeFlavour):
+    """Flavour used by PurePosixPath with some Unix specific implementations
+    independent of FakeFilesystem properties.
+    """
+
+    def is_reserved(self, parts):
+        return False
+
+    def make_uri(self, path):
+        # We represent the path using the local filesystem encoding,
+        # for portability to other applications.
+        bpath = bytes(path)
+        return 'file://' + urlquote_from_bytes(bpath)
+
+    def gethomedir(self, username):
+        # original version, not faked
+        if not username:
+            try:
+                return os.environ['HOME']
+            except KeyError:
+                import pwd
+                return pwd.getpwuid(os.getuid()).pw_dir
+        else:
+            import pwd
+            try:
+                return pwd.getpwnam(username).pw_dir
+            except KeyError:
+                raise RuntimeError("Can't determine home directory "
+                                   "for %r" % username)
+
+
+class FakePath(pathlib.Path):
+    """Replacement for pathlib.Path. Reimplement some methods to use fake filesystem.
+    The rest of the methods work as they are, as they will use the fake accessor.
+    """
+
+    # the underlying fake filesystem
+    filesystem = None
+
+    def __new__(cls, *args, **kwargs):
+        """Creates the correct subclass based on OS."""
+        if cls is FakePathlibModule.Path:
+            cls = FakePathlibModule.WindowsPath if os.name == 'nt' else FakePathlibModule.PosixPath
+        self = cls._from_parts(args, init=True)
+        return self
+
+    def _path(self):
+        """Returns the underlying path string as used by the fake filesystem."""
+        return str(self)
+
+    def _init(self, template=None):
+        """Initializer called from base class."""
+        self._accessor = _fake_accessor
+        self._closed = False
+
+    @classmethod
+    def cwd(cls):
+        """Return a new path pointing to the current working directory
+        (as returned by os.getcwd()).
+        """
+        return cls(cls.filesystem.cwd)
+
+    @classmethod
+    def home(cls):
+        """Return a new path pointing to the user's home directory (as
+        returned by os.path.expanduser('~')).
+        """
+        return cls(cls()._flavour.gethomedir(None).
+                   replace(os.sep, cls.filesystem.path_separator))
+
+    def samefile(self, other_path):
+        """Return whether other_path is the same or not as this file
+        (as returned by os.path.samefile()).
+
+        Args:
+            other_path: a path object or string of the file object to be compared with
+
+        Raises:
+          OSError: if the filesystem object doesn't exist.
+        """
+        st = self.stat()
+        try:
+            other_st = other_path.stat()
+        except AttributeError:
+            other_st = self.filesystem.GetStat(other_path)
+        return st.st_ino == other_st.st_ino and st.st_dev == other_st.st_dev
+
+    def resolve(self):
+        """Make the path absolute, resolving all symlinks on the way and also
+        normalizing it (for example turning slashes into backslashes under Windows).
+
+        Raises:
+            IOError: if the path doesn't exist
+        """
+        if self._closed:
+            self._raise_closed()
+        path = self.filesystem.ResolvePath(self._path())
+        return FakePath(path)
+
+    def open(self, mode='r', buffering=-1, encoding=None,
+             errors=None, newline=None):
+        """Open the file pointed by this path and return a fake file object.
+
+        Raises:
+            IOError: if the target object is a directory, the path is invalid or
+                permission is denied.
+        """
+        if self._closed:
+            self._raise_closed()
+        return FakeFileOpen(self.filesystem)(
+            self._path(), mode, buffering, encoding, errors, newline)
+
+    if sys.version_info >= (3, 5):
+        def read_bytes(self):
+            """Open the fake file in bytes mode, read it, and close the file.
+
+            Raises:
+                IOError: if the target object is a directory, the path is invalid or
+                    permission is denied.
+            """
+            with FakeFileOpen(self.filesystem)(self._path(), mode='rb') as f:
+                return f.read()
+
+        def read_text(self, encoding=None, errors=None):
+            """
+            Open the fake file in text mode, read it, and close the file.
+            """
+            with FakeFileOpen(self.filesystem)(
+                self._path(), mode='r', encoding=encoding, errors=errors) as f:
+                return f.read()
+
+        def write_bytes(self, data):
+            """Open the fake file in bytes mode, write to it, and close the file.
+            Args:
+                data: the bytes to be written
+            Raises:
+                IOError: if the target object is a directory, the path is invalid or
+                    permission is denied.
+            """
+            # type-check for the buffer interface before truncating the file
+            view = memoryview(data)
+            with FakeFileOpen(self.filesystem)(self._path(), mode='wb') as f:
+                return f.write(view)
+
+        def write_text(self, data, encoding=None, errors=None):
+            """Open the fake file in text mode, write to it, and close the file.
+
+            Args:
+                data: the string to be written
+                encoding: the encoding used for the string; if not given, the
+                    default locale encoding is used
+                errors: ignored
+            Raises:
+                TypeError: if data is not of type 'str'
+                IOError: if the target object is a directory, the path is invalid or
+                    permission is denied.
+            """
+            if not isinstance(data, str):
+                raise TypeError('data must be str, not %s' %
+                                data.__class__.__name__)
+            with FakeFileOpen(self.filesystem)(
+                self._path(), mode='w', encoding=encoding, errors=errors) as f:
+                return f.write(data)
+
+    def touch(self, mode=0o666, exist_ok=True):
+        """Create a fake file for the path with the given access mode, if it doesn't exist.
+
+        Args:
+            mode: the file mode for the file if it does not exist
+            exist_ok: if the file already exists and this is True, nothinh happens,
+                otherwise FileExistError is raised
+
+        Raises:
+            FileExistsError if the file exists and exits_ok is False.
+        """
+        if self._closed:
+            self._raise_closed()
+        if self.exists():
+            if exist_ok:
+                self.filesystem.UpdateTime(self._path(), None)
+            else:
+                raise FileExistsError
+        else:
+            fake_file = self.open('w')
+            fake_file.close()
+            self.chmod(mode)
+
+    def expanduser(self):
+        """ Return a new path with expanded ~ and ~user constructs
+        (as returned by os.path.expanduser)
+        """
+        return FakePath(os.path.expanduser(self._path())
+                        .replace(os.path.sep, self.filesystem.path_separator))
+
+
+class FakePathlibModule(object):
+    """Uses FakeFilesystem to provide a fake pathlib module replacement.
+
+    You need a fake_filesystem to use this:
+    `filesystem = fake_filesystem.FakeFilesystem()`
+    `fake_pathlib_module = fake_filesystem.FakePathlibModule(filesystem)`
+    """
+
+    def __init__(self, filesystem):
+        """
+        Initializes the module with the given filesystem.
+
+        Args:
+            filesystem: FakeFilesystem used to provide file system information
+        """
+        init_module(filesystem)
+        self._pathlib_module = pathlib
+
+    class PurePosixPath(pathlib.PurePath):
+        """A subclass of PurePath, that represents non-Windows filesystem paths"""
+        __slots__ = ()
+
+    class PureWindowsPath(pathlib.PurePath):
+        """A subclass of PurePath, that represents Windows filesystem paths"""
+        __slots__ = ()
+
+    if sys.platform == 'win32':
+        class WindowsPath(FakePath, PureWindowsPath):
+            """A subclass of Path and PureWindowsPath that represents
+            concrete Windows filesystem paths.
+            """
+            __slots__ = ()
+    else:
+        class PosixPath(FakePath, PurePosixPath):
+            """A subclass of Path and PurePosixPath that represents
+            concrete non-Windows filesystem paths.
+            """
+            __slots__ = ()
+
+    Path = FakePath
+
+    def __getattr__(self, name):
+        """Forwards any unfaked calls to the standard pathlib module."""
+        return getattr(self._pathlib_module, name)

--- a/pyfakefs/fake_tempfile.py
+++ b/pyfakefs/fake_tempfile.py
@@ -51,6 +51,8 @@ class FakeTempfileModule(object):
         self.tempdir = None  # initialized by mktemp(), others
         self._temp_prefix = 'tmp'
         self._mktemp_retvals = []
+        # pylint: disable=protected-access
+        self._randomSequence = self._tempfile._RandomNameSequence()
 
     def _TempFilename(self, suffix='', prefix=None, directory=None):
         """Create a temporary filename that does not exist.
@@ -75,11 +77,11 @@ class FakeTempfileModule(object):
         if prefix is None:
             prefix = self._temp_prefix
         while not filename or self._filesystem.Exists(filename):
-            # pylint: disable=protected-access
             filename = self._filesystem.JoinPaths(directory, '%s%s%s' % (
                 prefix,
-                next(self._tempfile._RandomNameSequence()),
+                next(self._randomSequence),
                 suffix))
+            print(filename)
         return filename
 
     # pylint: disable=redefined-builtin,unused-argument,too-many-arguments

--- a/pyfakefs/fake_tempfile.py
+++ b/pyfakefs/fake_tempfile.py
@@ -81,7 +81,6 @@ class FakeTempfileModule(object):
                 prefix,
                 next(self._randomSequence),
                 suffix))
-            print(filename)
         return filename
 
     # pylint: disable=redefined-builtin,unused-argument,too-many-arguments


### PR DESCRIPTION
- added tests for most faked functions that accepts a path-like object
in 3.6
- adapted the code respectively by calling os.fspath() where needed
- added getatime() and getctime() to fake os module
